### PR TITLE
Add custom errors  `MethodNotAllowedError` and `ServiceError` and `ForbiddenError`

### DIFF
--- a/infra/auth_middleware.js
+++ b/infra/auth_middleware.js
@@ -1,0 +1,12 @@
+import { ForbiddenError } from "infra/errors";
+
+export default function authMiddleware(request, response, next) {
+    if (request.headers["x-test-auth"] === "fail") {
+        throw new ForbiddenError(
+            "Simulating a blocked anonymous user for tests.",
+        );
+    }
+
+    return next();
+}
+

--- a/infra/auth_middleware.js
+++ b/infra/auth_middleware.js
@@ -1,12 +1,9 @@
 import { ForbiddenError } from "infra/errors";
 
 export default function authMiddleware(request, response, next) {
-    if (request.headers["x-test-auth"] === "fail") {
-        throw new ForbiddenError(
-            "Simulating a blocked anonymous user for tests.",
-        );
-    }
+  if (request.headers["x-test-auth"] === "fail") {
+    throw new ForbiddenError("Simulating a blocked anonymous user for tests.");
+  }
 
-    return next();
+  return next();
 }
-

--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,0 +1,37 @@
+import {
+  InternalServerError,
+  MethodNotAllowedError,
+  ForbiddenError,
+} from "infra/errors";
+
+function onNoMatchHandler(request, response) {
+  const publicErrorObject = new MethodNotAllowedError();
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+function onErrorHandler(error, request, response) {
+  if (
+    error instanceof MethodNotAllowedError ||
+    error instanceof ForbiddenError
+  ) {
+    return response.status(error.statusCode).json(error);
+  }
+
+  const publicErrorObject = new InternalServerError({
+    statusCode: error.statusCode,
+    cause: error,
+  });
+
+  console.error(publicErrorObject);
+
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+const controller = {
+  errorHandlers: {
+    onNoMatch: onNoMatchHandler,
+    onError: onErrorHandler,
+  },
+};
+
+export default controller;

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,4 +1,5 @@
 import { Client } from "pg";
+import { ServiceError } from "./errors.js";
 
 async function query(queryObject) {
   let client;
@@ -7,9 +8,11 @@ async function query(queryObject) {
     const result = await client.query(queryObject);
     return result;
   } catch (error) {
-    console.log("\n Erro dentro do catch do database.js");
-    console.error(error);
-    throw error;
+    const serviceErrorObject = new ServiceError({
+      message: "Failed to connect with the database or in the query.",
+      cause: error,
+    });
+    throw serviceErrorObject;
   } finally {
     await client?.end();
   }

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,11 +1,28 @@
 export class InternalServerError extends Error {
-  constructor({ cause }) {
-    super("Um erro interno não esperado aconteceu.", {
+  constructor({ cause, statusCode }) {
+    super("An unexpected internal error occurred.", {
       cause,
     });
     this.name = "InternalServerError";
-    this.action = "Entre em contato com o suporte técnico.";
-    this.statusCode = 500;
+    this.action = "Please contact technical support.";
+    this.statusCode = statusCode || 500;
+  }
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class ServiceError extends Error {
+  constructor({ cause, message }) {
+    super(message || "Service currently unavailable.", { cause });
+    this.name = "ServiceError";
+    this.action = "Check if the service is currently available.";
+    this.statusCode = 503;
   }
   toJSON() {
     return {

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -33,3 +33,20 @@ export class MethodNotAllowedError extends Error {
     };
   }
 }
+
+export class ForbiddenError extends Error {
+  constructor() {
+    super("You do not have permission to access this action.");
+    this.name = "ForbiddenError";
+    this.action = "Provide a valid authentication token with the required permissions.";
+    this.statusCode = 403;
+  }
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -38,7 +38,8 @@ export class ForbiddenError extends Error {
   constructor() {
     super("You do not have permission to access this action.");
     this.name = "ForbiddenError";
-    this.action = "Provide a valid authentication token with the required permissions.";
+    this.action =
+      "Provide a valid authentication token with the required permissions.";
     this.statusCode = 403;
   }
   toJSON() {

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -16,3 +16,20 @@ export class InternalServerError extends Error {
     };
   }
 }
+
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    super("Method not allowed for this endpoint.");
+    this.name = "MethodNotAllowedError";
+    this.action = "Verify if the HTTP method is valid for this endpoint.";
+    this.statusCode = 405;
+  }
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "eslint": "9.31.0",
         "eslint-config-next": "15.4.3",
         "next": "15.4.3",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "^7.6.1",
         "pg": "8.16.3",
         "react": "18.2.0",
@@ -2568,6 +2569,12 @@
       "dependencies": {
         "tslib": "^2.8.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
@@ -8312,6 +8319,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9162,6 +9182,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "services:wait:database": "node infra/scripts/wait-for-postgres.js",
     "migrations:create": "node-pg-migrate -m infra/migrations create",
     "migrations:up": "node-pg-migrate -m infra/migrations --envPath .env.development up",
-    "migrations:down": "node-pg-migrate -m infra/migrations down",
+    "migrations:down": "node-pg-migrate -m infra/migrations --envPath .env.development down",
     "lint:prettier:check": "prettier --check .",
     "lint:prettier:fix": "prettier --write .",
     "lint:eslint:check": "next lint --dir .",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint": "9.31.0",
     "eslint-config-next": "15.4.3",
     "next": "15.4.3",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "^7.6.1",
     "pg": "8.16.3",
     "react": "18.2.0",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,51 +1,88 @@
+import { createRouter } from "next-connect";
+import {
+  InternalServerError,
+  MethodNotAllowedError,
+  ForbiddenError,
+} from "infra/errors";
+import authMiddleware from "infra/auth_middleware";
 import migrationRunner from "node-pg-migrate";
 import { resolve } from "node:path";
 import database from "infra/database";
 
-export default async function migrations(request, response) {
-  const allowedMethods = ["GET", "POST"];
-  if (!allowedMethods.includes(request.method)) {
-    return response.status(405).json({
-      error: `Method ${request.method} not allowed!`,
-    });
+const router = createRouter();
+
+router.use(authMiddleware);
+router.get(getMigrationsHandler);
+router.post(postMigrationsHandler);
+
+export default router.handler({
+  onNoMatch: onNoMatchHandler,
+  onError: onErrorHandler,
+});
+
+function onNoMatchHandler(request, response) {
+  const publicErrorObject = new MethodNotAllowedError();
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+function onErrorHandler(error, request, response) {
+  if (
+    error instanceof MethodNotAllowedError ||
+    error instanceof ForbiddenError
+  ) {
+    return response.status(error.statusCode).json(error);
   }
 
-  let dbClient;
+  const publicErrorObject = new InternalServerError({
+    cause: error,
+  });
 
+  console.error("Erro capturado pelo onError do next-connect:", error);
+  console.error(publicErrorObject);
+
+  response.status(500).json(publicErrorObject);
+}
+
+async function getMigrationsHandler(request, response) {
+  let dbClient;
   try {
     dbClient = await database.getNewClient();
-
-    const defaultMigrationsOptions = {
+    const pendingMigrations = await migrationRunner({
       dbClient: dbClient,
       dryRun: true,
       dir: resolve("infra", "migrations"),
       direction: "up",
       verbose: true,
       migrationsTable: "pgmigrations",
-    };
+    });
+    response.status(200).json(pendingMigrations);
+  } finally {
+    if (dbClient) await dbClient.end();
+  }
+}
 
-    if (request.method === "GET") {
-      const pendingMigrations = await migrationRunner(defaultMigrationsOptions);
+async function postMigrationsHandler(request, response) {
+  let dbClient;
+  try {
+    dbClient = await database.getNewClient();
 
-      return response.status(200).json(pendingMigrations);
+    const migratedMigrations = await migrationRunner({
+      dbClient: dbClient,
+      dryRun: false,
+      dir: resolve("infra", "migrations"),
+      direction: "up",
+      verbose: true,
+      migrationsTable: "pgmigrations",
+    });
+
+    if (migratedMigrations.length > 0) {
+      return response.status(201).json(migratedMigrations);
     }
-
-    if (request.method === "POST") {
-      const migratedMigrations = await migrationRunner({
-        ...defaultMigrationsOptions,
-        dryRun: false,
-      });
-
-      if (migratedMigrations.length > 0) {
-        return response.status(201).json(migratedMigrations);
-      }
-
-      return response.status(200).json(migratedMigrations);
-    }
+    response.status(200).json(migratedMigrations);
   } catch (error) {
     console.error(error);
     throw error;
   } finally {
-    await dbClient.end();
+    if (dbClient) await dbClient.end();
   }
 }

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,46 +1,60 @@
+import { createRouter } from "next-connect";
 import database from "infra/database";
-import { InternalServerError } from "infra/errors";
+import { InternalServerError, MethodNotAllowedError } from "infra/errors";
 
-async function status(request, response) {
-  try {
-    const updatedAt = new Date().toISOString();
+const router = createRouter();
 
-    const databaseVersionResult = await database.query("SHOW server_version;");
-    const databaseVersionValue = databaseVersionResult.rows[0].server_version;
+router.get(getHandler);
 
-    const databaseMaxConnectionsResult = await database.query(
-      "SHOW max_connections;",
-    );
-    const postgresConnection =
-      databaseMaxConnectionsResult.rows[0].max_connections;
+export default router.handler({
+  onNoMatch: onNoMatchHandler,
+  onError: onErrorHandler,
+});
 
-    const databaseName = process.env.POSTGRES_DB;
-    const databaseOpenedConnectionsResult = await database.query({
-      text: "SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;",
-      values: [databaseName],
-    });
-    const databaseOpenedConnections =
-      databaseOpenedConnectionsResult.rows[0].count;
-
-    response.status(200).json({
-      updated_at: updatedAt,
-      dependencies: {
-        database: {
-          version: databaseVersionValue,
-          max_connections: parseInt(postgresConnection),
-          opened_connections: databaseOpenedConnections,
-        },
-      },
-    });
-  } catch (error) {
-    const publicErrorObject = new InternalServerError({
-      cause: error,
-    });
-    console.log("\n Erro dentro do catch do controller:");
-    console.error(publicErrorObject);
-
-    response.status(500).json(publicErrorObject);
-  }
+function onNoMatchHandler(request, response) {
+  const publicErrorObject = new MethodNotAllowedError();
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
 }
 
-export default status;
+function onErrorHandler(error, request, response) {
+  const publicErrorObject = new InternalServerError({
+    cause: error,
+  });
+
+  console.log("\n Erro dentro do catch do controller:");
+  console.error(publicErrorObject);
+
+  response.status(500).json(publicErrorObject);
+}
+
+async function getHandler(request, response) {
+  const updatedAt = new Date().toISOString();
+
+  const databaseVersionResult = await database.query("SHOW server_version;");
+  const databaseVersionValue = databaseVersionResult.rows[0].server_version;
+
+  const databaseMaxConnectionsResult = await database.query(
+    "SHOW max_connections;",
+  );
+  const postgresConnection =
+    databaseMaxConnectionsResult.rows[0].max_connections;
+
+  const databaseName = process.env.POSTGRES_DB;
+  const databaseOpenedConnectionsResult = await database.query({
+    text: "SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;",
+    values: [databaseName],
+  });
+  const databaseOpenedConnections =
+    databaseOpenedConnectionsResult.rows[0].count;
+
+  response.status(200).json({
+    updated_at: updatedAt,
+    dependencies: {
+      database: {
+        version: databaseVersionValue,
+        max_connections: parseInt(postgresConnection),
+        opened_connections: databaseOpenedConnections,
+      },
+    },
+  });
+}

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,31 +1,12 @@
 import { createRouter } from "next-connect";
 import database from "infra/database";
-import { InternalServerError, MethodNotAllowedError } from "infra/errors";
+import controller from "infra/controller";
 
 const router = createRouter();
 
 router.get(getHandler);
 
-export default router.handler({
-  onNoMatch: onNoMatchHandler,
-  onError: onErrorHandler,
-});
-
-function onNoMatchHandler(request, response) {
-  const publicErrorObject = new MethodNotAllowedError();
-  response.status(publicErrorObject.statusCode).json(publicErrorObject);
-}
-
-function onErrorHandler(error, request, response) {
-  const publicErrorObject = new InternalServerError({
-    cause: error,
-  });
-
-  console.log("\n Erro dentro do catch do controller:");
-  console.error(publicErrorObject);
-
-  response.status(500).json(publicErrorObject);
-}
+export default router.handler(controller.errorHandlers);
 
 async function getHandler(request, response) {
   const updatedAt = new Date().toISOString();

--- a/tests/integration/api/v1/migrations/post.test.js
+++ b/tests/integration/api/v1/migrations/post.test.js
@@ -7,6 +7,30 @@ beforeAll(async () => {
 
 describe("POST /api/v1/migrations", () => {
   describe("Anonymous user", () => {
+    test("Should not allow running migrations", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/migrations", {
+        method: "POST",
+        headers: {
+          "X-Test-Auth": "fail",
+        },
+      });
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "ForbiddenError",
+        message: "You do not have permission to access this action.",
+        action: "Provide a valid authentication token with the required permissions.",
+        status_code: 403,
+      });
+    });
+  });
+});
+
+describe("POST /api/v1/migrations", () => {
+  describe("Authorized user", () => {
     describe("Retrieving pending migrations", () => {
       test("For the first time", async () => {
         const response1 = await fetch(

--- a/tests/integration/api/v1/migrations/post.test.js
+++ b/tests/integration/api/v1/migrations/post.test.js
@@ -22,42 +22,34 @@ describe("POST /api/v1/migrations", () => {
       expect(responseBody).toEqual({
         name: "ForbiddenError",
         message: "You do not have permission to access this action.",
-        action: "Provide a valid authentication token with the required permissions.",
+        action:
+          "Provide a valid authentication token with the required permissions.",
         status_code: 403,
       });
     });
   });
-});
 
-describe("POST /api/v1/migrations", () => {
   describe("Authorized user", () => {
-    describe("Retrieving pending migrations", () => {
-      test("For the first time", async () => {
-        const response1 = await fetch(
-          "http://localhost:3000/api/v1/migrations",
-          {
-            method: "POST",
-          },
-        );
-        expect(response1.status).toBe(201);
-        const response1Body = await response1.json();
-
-        expect(Array.isArray(response1Body)).toEqual(true);
-        expect(response1Body.length).toBeGreaterThan(0);
+    test("Retrieving pending migrations for the first time", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/migrations", {
+        method: "POST",
       });
-      test("For the second time", async () => {
-        const response2 = await fetch(
-          "http://localhost:3000/api/v1/migrations",
-          {
-            method: "POST",
-          },
-        );
-        expect(response2.status).toBe(200);
-        const response2Body = await response2.json();
+      expect(response1.status).toBe(201);
+      const response1Body = await response1.json();
 
-        expect(Array.isArray(response2Body)).toEqual(true);
-        expect(response2Body.length).toBe(0);
+      expect(Array.isArray(response1Body)).toEqual(true);
+      expect(response1Body.length).toBeGreaterThan(0);
+    });
+
+    test("Retrieving pending migrations for the second time", async () => {
+      const response2 = await fetch("http://localhost:3000/api/v1/migrations", {
+        method: "POST",
       });
+      expect(response2.status).toBe(200);
+      const response2Body = await response2.json();
+
+      expect(Array.isArray(response2Body)).toEqual(true);
+      expect(response2Body.length).toBe(0);
     });
   });
 });

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -1,0 +1,25 @@
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+describe("POST /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Retrieving current system status", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/status", {
+        method: "POST",
+      });
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Method not allowed for this endpoint.",
+        action: "Verify if the HTTP method is valid for this endpoint.",
+        status_code: 405,
+      });
+    });
+  });
+});


### PR DESCRIPTION
1. Padroniza os Controllers dos endpoints `/migrations` e `/status`.
2. Adiciona 2 novos erros customizados: `MethodNotAllowedError ` e `ServiceError`.
3. Faz o `InternalServerError ` aceitar injeção do `statusCode`.